### PR TITLE
arm: force arm code generation for co_switch

### DIFF
--- a/arm.c
+++ b/arm.c
@@ -80,6 +80,7 @@ void co_delete(cothread_t handle) {
   free(handle);
 }
 
+__attribute__((target("arm")))
 void co_switch(cothread_t handle) {
   cothread_t co_previous_handle = co_active_handle;
   co_swap(co_active_handle = handle, co_previous_handle);


### PR DESCRIPTION
When libco is built with thumb instructions, there is no guarantee that co_swap
will be called with a bx instruction to switch out of thumb. Force co_switch to
be built with 32-bit arm instructions to work around this.